### PR TITLE
Speed up and simplify tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM golang:1.11
+FROM golang:1.18.3-alpine3.16
 
-RUN apt-get update && apt-get install -y --no-install-recommends default-mysql-client postgresql-client && rm -rf /var/lib/apt/lists/*
+ENV CGO_ENABLED=0
+
+RUN apk add --no-cache mysql-client postgresql-client
 
 ENTRYPOINT [ "go", "test", "-v", "." ]

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
-all: build
-OS = $(shell uname | tr [:upper:] [:lower:])
 ARTIFACT = sql
 
-build: GOOS ?= ${OS}
-build: test
-		GOOS=${GOOS} GOARCH=amd64 CGO_ENABLED=0 go build -o ${ARTIFACT} -a .
+all: test build
+
+build: export CGO_ENABLED=0
+build:
+	go build -o ${ARTIFACT} .
 
 test:
-	docker-compose --file test-docker-compose.yml up --abort-on-container-exit --force-recreate --renew-anon-volumes
+	docker-compose run --rm test
 
-run: build
-	./${ARTIFACT}
+clean:
+	docker-compose down -v
+	docker-compose rm test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3.9"
 services:
   test:
     build: .
@@ -6,16 +6,16 @@ services:
       - "$PWD:/go/src/sql"
     working_dir: /go/src/sql
     depends_on:
-      - test-mysql
-      - test-postgres
-  test-mysql:
+      - mysql
+      - postgres
+  mysql:
     image: mysql:5.7
     volumes:
       - ./mysql_test_schemas.sql:/docker-entrypoint-initdb.d/mysql_test_schemas.sql
     environment:
       MYSQL_ROOT_PASSWORD:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-  test-postgres:
+  postgres:
     image: postgres:9-alpine
     volumes:
       - ./postgres_test_schemas.sql:/docker-entrypoint-initdb.d/postgres_test_schemas.sql

--- a/main_test.go
+++ b/main_test.go
@@ -99,9 +99,9 @@ func Test_MySQL(t *testing.T) {
 
 	var (
 		testConfig = testConfig{
-			"db1": database{DbServer: "test-mysql", DbName: "db1", User: "root", Pass: "", SQLType: "mysql"},
-			"db2": database{DbServer: "test-mysql", DbName: "db2", User: "root", Pass: "", SQLType: ""},
-			"db3": database{DbServer: "test-mysql", DbName: "db3", User: "root", Pass: "", SQLType: ""},
+			"db1": database{DbServer: "mysql", DbName: "db1", User: "root", Pass: "", SQLType: "mysql"},
+			"db2": database{DbServer: "mysql", DbName: "db2", User: "root", Pass: "", SQLType: ""},
+			"db3": database{DbServer: "mysql", DbName: "db3", User: "root", Pass: "", SQLType: ""},
 		}
 	)
 	runTests(baseTests, testConfig, t)
@@ -113,9 +113,9 @@ func Test_PostgreSQL(t *testing.T) {
 
 	var (
 		testConfig = testConfig{
-			"db1": database{DbServer: "test-postgres", DbName: "db1", User: "root", Pass: "", SQLType: "postgres"},
-			"db2": database{DbServer: "test-postgres", DbName: "db2", User: "root", Pass: "", SQLType: "postgres"},
-			"db3": database{DbServer: "test-postgres", DbName: "db3", User: "root", Pass: "", SQLType: "postgres"},
+			"db1": database{DbServer: "postgres", DbName: "db1", User: "root", Pass: "", SQLType: "postgres"},
+			"db2": database{DbServer: "postgres", DbName: "db2", User: "root", Pass: "", SQLType: "postgres"},
+			"db3": database{DbServer: "postgres", DbName: "db3", User: "root", Pass: "", SQLType: "postgres"},
 		}
 	)
 	runTests(baseTests, testConfig, t)
@@ -127,10 +127,10 @@ func Test_Mix_Mysql_PostgreSQL(t *testing.T) {
 
 	var (
 		testConfig = testConfig{
-			"db1": database{DbServer: "test-postgres", DbName: "db1", User: "root", Pass: "", SQLType: "postgres"},
-			"db2": database{DbServer: "test-postgres", DbName: "db2", User: "root", Pass: "", SQLType: "postgres"},
-			"db3": database{DbServer: "test-mysql", DbName: "db3", User: "root", Pass: "", SQLType: ""},
-			"db4": database{DbServer: "test-mysql", DbName: "db1", User: "root", Pass: "", SQLType: "mysql"},
+			"db1": database{DbServer: "postgres", DbName: "db1", User: "root", Pass: "", SQLType: "postgres"},
+			"db2": database{DbServer: "postgres", DbName: "db2", User: "root", Pass: "", SQLType: "postgres"},
+			"db3": database{DbServer: "mysql", DbName: "db3", User: "root", Pass: "", SQLType: ""},
+			"db4": database{DbServer: "mysql", DbName: "db1", User: "root", Pass: "", SQLType: "mysql"},
 		}
 		ts = tests{
 			{
@@ -207,8 +207,8 @@ func runTests(ts tests, testConfig testConfig, t *testing.T) {
 }
 
 func awaitDB(typ sqlType, t *testing.T) {
-	var pgTestCmds = []string{"-h", "test-postgres", "-U", "root", "-d", "db1", "-c", "SELECT * FROM table1"}
-	var msTestCmds = []string{"-h", "test-mysql", "-u", "root", "-e", "SELECT * FROM db1.table1"}
+	var pgTestCmds = []string{"-h", "postgres", "-U", "root", "-d", "db1", "-c", "SELECT * FROM table1"}
+	var msTestCmds = []string{"-h", "mysql", "-u", "root", "-e", "SELECT * FROM db1.table1"}
 	var err error
 	var c *exec.Cmd
 	for i := 1; i <= 30; i++ {


### PR DESCRIPTION
Running via docker-compose run is percepitbly faster, probably due to less logging and less rebuilt work. More likely to leave things in a dirty state though 